### PR TITLE
Account for spacing and changing default Dockerfile env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,16 +29,16 @@ ENV SERVER_DATA_PATH="/home/steam/vrising/server" \
     HOST_SETTINGS_AUTOSAVE_INTERVAL="120" \
     HOST_SETTINGS_LISTEN_ON_STEAM="true" \ 
     HOST_SETTINGS_LISTEN_ON_EOS="true" \
-    GAME_SETTINGS_PRESET="StandardPvP" \
+    GAME_SETTINGS_PRESET="" \
     GAME_SETTINGS_DIFFICULTY="Normal" \
     LIST_ON_MASTER_SERVER="true" \
     SERVER_IP="127.0.0.1" \
-    SAVE_NAME="default_world" \
+    SAVE_NAME="world1" \
     GAME_PORT="9876" \
     QUERY_PORT="9877" \
     DEBUG_ENV="true" \
     LOGDAYS="30" \
-    OVERRIDE_CONFIG="true" \
+    OVERRIDE_CONFIG="false" \
     TZ="Europe/Brussels"
 
 COPY --chown=${STEAM_USER_UID}:${STEAM_USER_GID} --chmod=744 files /home/steam/files/

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ENV SERVER_DATA_PATH="/home/steam/vrising/server" \
     HOST_SETTINGS_AUTOSAVE_INTERVAL="120" \
     HOST_SETTINGS_LISTEN_ON_STEAM="true" \ 
     HOST_SETTINGS_LISTEN_ON_EOS="true" \
-    GAME_SETTINGS_PRESET="" \
+    GAME_SETTINGS_PRESET="StandardPvP" \
     GAME_SETTINGS_DIFFICULTY="Normal" \
     LIST_ON_MASTER_SERVER="true" \
     SERVER_IP="127.0.0.1" \
@@ -38,7 +38,7 @@ ENV SERVER_DATA_PATH="/home/steam/vrising/server" \
     QUERY_PORT="9877" \
     DEBUG_ENV="true" \
     LOGDAYS="30" \
-    OVERRIDE_CONFIG="false" \
+    OVERRIDE_CONFIG="true" \
     TZ="Europe/Brussels"
 
 COPY --chown=${STEAM_USER_UID}:${STEAM_USER_GID} --chmod=744 files /home/steam/files/

--- a/files/configs/supervisord.conf
+++ b/files/configs/supervisord.conf
@@ -12,7 +12,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:vrisingserver]
-command=xvfb-run --auto-servernum --server-args='-screen 0 640x480x24:32' wine "%(ENV_SERVER_DATA_PATH)s/VRisingServer.exe" -persistentDataPath "%(ENV_PERSISTENT_DATA_PATH)s" -serverName "%(ENV_HOST_SETTINGS_NAME)s" -saveName "%(ENV_SAVE_NAME)s" -logFile "%(ENV_PERSISTENT_DATA_PATH)s/%(ENV_logfile)s" %(ENV_GAME_PORT)s %(ENV_QUERY_PORT)s 2>&1
+command=xvfb-run --auto-servernum --server-args='-screen 0 640x480x24:32' wine "%(ENV_SERVER_DATA_PATH)s/VRisingServer.exe" -persistentDataPath "%(ENV_PERSISTENT_DATA_PATH)s" -logFile "%(ENV_PERSISTENT_DATA_PATH)s/%(ENV_logfile)s" %(ENV_GAME_PORT)s %(ENV_QUERY_PORT)s 2>&1
 autorestart=false
 numprocs=1
 startsecs=0

--- a/files/configs/supervisord.conf
+++ b/files/configs/supervisord.conf
@@ -1,5 +1,5 @@
 [supervisord]
-logfile=%(ENV_PERSISTENT_DATA_PATH)s/%(ENV_logfile)s
+logfile="%(ENV_PERSISTENT_DATA_PATH)s/%(ENV_logfile)s"
 nodaemon=true
 logfile_maxbytes = 0
 
@@ -22,7 +22,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:tailtostdout]
-command=tail -f %(ENV_PERSISTENT_DATA_PATH)s/%(ENV_logfile)s
+command=tail -f "%(ENV_PERSISTENT_DATA_PATH)s/%(ENV_logfile)s"
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/files/configs/supervisord.conf
+++ b/files/configs/supervisord.conf
@@ -12,7 +12,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:vrisingserver]
-command=xvfb-run --auto-servernum --server-args='-screen 0 640x480x24:32' wine %(ENV_SERVER_DATA_PATH)s/VRisingServer.exe -persistentDataPath %(ENV_PERSISTENT_DATA_PATH)s -serverName %(ENV_HOST_SETTINGS_NAME)s -saveName %(ENV_SAVE_NAME)s -logFile %(ENV_PERSISTENT_DATA_PATH)s/%(ENV_logfile)s %(ENV_GAME_PORT)s %(ENV_QUERY_PORT)s 2>&1
+command=xvfb-run --auto-servernum --server-args='-screen 0 640x480x24:32' wine "%(ENV_SERVER_DATA_PATH)s/VRisingServer.exe" -persistentDataPath "%(ENV_PERSISTENT_DATA_PATH)s" -serverName "%(ENV_HOST_SETTINGS_NAME)s" -saveName "%(ENV_SAVE_NAME)s" -logFile "%(ENV_PERSISTENT_DATA_PATH)s/%(ENV_logfile)s" %(ENV_GAME_PORT)s %(ENV_QUERY_PORT)s 2>&1
 autorestart=false
 numprocs=1
 startsecs=0

--- a/files/configs/supervisord.conf
+++ b/files/configs/supervisord.conf
@@ -1,5 +1,5 @@
 [supervisord]
-logfile="%(ENV_PERSISTENT_DATA_PATH)s/%(ENV_logfile)s"
+logfile=%(ENV_PERSISTENT_DATA_PATH)s/%(ENV_logfile)s
 nodaemon=true
 logfile_maxbytes = 0
 


### PR DESCRIPTION
We need to account for spaces in these areas or else it will only accept one word or break if it's a PATH.
Changing Dockerfile as we shouldn't overwrite data by default, setting a template causes the server to never load custom preset (user should set a preset if they want this), and changing world name to allow users from older versions to run without setting this themselves.